### PR TITLE
Fix bare excepts in date extraction

### DIFF
--- a/src/utils/date_extractor.py
+++ b/src/utils/date_extractor.py
@@ -213,7 +213,9 @@ def extract_date_from_text_patterns(html: Any) -> Optional[str]:
     """Extract dates using common text patterns."""
     try:
         full_text = html.body.text() if html.body else ""
-    except:
+    except AttributeError:
+        # Fallback to the generic text representation if the body element is
+        # missing. Allow other errors to propagate for easier debugging.
         full_text = html.text() if hasattr(html, "text") else ""
 
     date_patterns = [
@@ -329,7 +331,9 @@ def extract_date_from_government_site(html: Any, domain: str) -> Optional[str]:
     """Special handling for government websites."""
     try:
         full_text = html.body.text() if html.body else ""
-    except:
+    except AttributeError:
+        # Some government pages might not have a <body> element. Use the raw
+        # text as a fallback but allow unexpected exceptions to surface.
         full_text = html.text() if hasattr(html, "text") else ""
 
     # Check for specific government site patterns


### PR DESCRIPTION
## Summary
- improve error handling in `extract_date_from_text_patterns`
- improve error handling in `extract_date_from_government_site`

## Testing
- `pytest -q --ignore=venv`

------
https://chatgpt.com/codex/tasks/task_e_6876b2509a30833187eb15b4e2dd7487