### PR TITLE
Remove current date fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Python application for analyzing the impact of hurricanes and other disasters 
 ## Features
 
 * **Automated Article Search** : Uses Google Custom Search API to find articles about specific disasters and their impact on US communications systems
-* **Content Analysis** : Extracts publication dates and relevant impact details from articles
+* **Content Analysis** : Extracts publication dates and relevant impact details from articles. If a date can't be determined, the system records "Date unknown".
 * **Data Extraction** : Identifies mentions of communications infrastructure damage and outages
 * **Report Generation** : Creates Excel reports with organized findings
 * **User-friendly GUI** : Easy-to-use interface for setting search parameters and viewing progress

--- a/docs/storm-analysis-documentation.md
+++ b/docs/storm-analysis-documentation.md
@@ -196,6 +196,7 @@ The end result is a spreadsheet that shows which communications systems were aff
    * It downloads the HTML content
    * It parses the HTML to extract text
    * It looks for the publication date using multiple methods
+   * If no date can be found, it records "Date unknown" rather than using today's date
    * It identifies paragraphs about communications impacts
    * It scores these paragraphs based on relevance
    * It extracts the most informative content

--- a/src/utils/article_analyzer.py
+++ b/src/utils/article_analyzer.py
@@ -269,18 +269,7 @@ async def analyze_article_async(
         result.error = f"Error analyzing article: {str(e)}"
         stats.error_count += 1
 
-    # Final fallback: If we couldn't extract a date but we're on a .gov or .mil site, use today's date
-    if (
-        not result.publication_info.date
-        and domain
-        and ("gov" in domain or "mil" in domain)
-    ):
-        from datetime import datetime
-
-        result.publication_info.date = datetime.now().strftime("%Y-%m-%d")
-        logger.info(
-            f"Using current date for government/military site: {result.publication_info.date}"
-        )
+    # No fallback to current date. If no publication date is found, record "Date unknown" later.
 
     # Calculate processing time
     stats.processing_time_ms = (time.time() - start_time) * 1000

--- a/src/utils/date_extractor.py
+++ b/src/utils/date_extractor.py
@@ -122,10 +122,8 @@ def extract_and_normalize_date(
         if date_str:
             logger.info(f"Date from gov/mil site: {date_str}")
             return normalize_date(date_str)
-        # fallback: use current date
-        today = datetime.now().strftime("%Y-%m-%d")
-        logger.info(f"Fallback current date: {today}")
-        return today
+        logger.warning("No date found on government/military site")
+        return None
 
     logger.warning(f"No date found for {url}")
     return None


### PR DESCRIPTION
## Summary
- avoid defaulting to the current date when a government site date can't be found
- clarify behaviour in the documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b3dec7f08331b55ded4de3c207d0