### PR TITLE
Remove unused Union import

### DIFF
--- a/src/utils/date_extractor.py
+++ b/src/utils/date_extractor.py
@@ -9,7 +9,7 @@ import re
 import logging
 from datetime import datetime
 from dateparser import parse as parse_date
-from typing import Optional, Dict, Any, List, Union
+from typing import Optional, Dict, Any, List
 from urllib.parse import urlparse
 import json
 


### PR DESCRIPTION
## Summary
- clean up `src/utils/date_extractor` by removing an unused `Union` import

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6876b56aaedc8331ba43ac950e421135