### PR TITLE
Refactor to centralize sector constants

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -22,6 +22,14 @@ Attributes:
 # Standard library imports
 from typing import List
 
+# Import shared configuration lists
+from .config import (
+    PRIORITY_1_SECTORS,
+    PRIORITY_2_SECTORS,
+    ALL_SECTORS,
+    DISASTER_TYPES,
+)
+
 # Local imports
 from .utils.article_analyzer import analyze_article, analyze_articles
 from .utils.impact_analyzer import extract_structured_impact_details
@@ -31,44 +39,8 @@ from .utils.search_api import search_articles
 __version__ = "1.0.0"
 __author__ = "Disaster Impact Analysis Team"
 
-# Define common data available throughout the package
-PRIORITY_1_SECTORS: List[str] = [
-    "Chemical",
-    "Commercial Facilities",
-    "Communications",
-    "Critical Manufacturing",
-    "Dams",
-    "Emergency Services",
-    "Information Technology",
-    "Nuclear",
-    "Transportation",
-    "Government Facilities",
-]
-
-PRIORITY_2_SECTORS: List[str] = [
-    "Energy",
-    "Water",
-    "Defense",
-    "Financial",
-    "Healthcare",
-    "Food and Agriculture",
-]
-
-ALL_SECTORS: List[str] = PRIORITY_1_SECTORS + PRIORITY_2_SECTORS
-
-DISASTER_TYPES: List[str] = [
-    "Hurricane",
-    "Earthquake",
-    "Flood",
-    "Fire",
-    "Tornado",
-    "Tsunami",
-    "Drought",
-    "Landslide",
-    "Volcanic Eruption",
-    "Winter Storm",
-    "Heat Wave",
-]
+# The infrastructure sector lists and supported disaster types are
+# defined in :mod:`src.config` and imported above for convenience.
 
 __all__ = [
     # Version information

--- a/src/gui/gui_app.py
+++ b/src/gui/gui_app.py
@@ -16,47 +16,16 @@ import src.utils.search_api as search_api
 import src.utils.article_analyzer as article_analyzer
 import src.utils.report_generator as report_generator
 
+# Shared configuration lists
+from src.config import (
+    PRIORITY_1_SECTORS,
+    PRIORITY_2_SECTORS,
+    ALL_SECTORS,
+    DISASTER_TYPES,
+)
 
-# Define available sectors
-PRIORITY_1_SECTORS = [
-    "Chemical",
-    "Commercial Facilities",
-    "Communications",
-    "Critical Manufacturing",
-    "Dams",
-    "Emergency Services",
-    "Information Technology",
-    "Nuclear",
-    "Transportation",
-    "Government Facilities",
-]
 
-PRIORITY_2_SECTORS = [
-    "Energy",
-    "Water",
-    "Defense",
-    "Financial",
-    "Healthcare",
-    "Food and Agriculture",
-]
-
-ALL_SECTORS = PRIORITY_1_SECTORS + PRIORITY_2_SECTORS
-
-# Define disaster types
-DISASTER_TYPES = [
-    "Hurricane",
-    "Earthquake",
-    "Flood",
-    "Fire",
-    "Tornado",
-    "Tsunami",
-    "Drought",
-    "Landslide",
-    "Volcanic Eruption",
-    "Winter Storm",
-    "Heat Wave",
-    "Other",
-]
+# Sector definitions and disaster types are imported from ``src.config``
 
 
 class RedirectText:

--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,14 @@ import os
 import sys
 from typing import List, Optional, Tuple
 
+# Shared configuration
+from config import (
+    PRIORITY_1_SECTORS,
+    PRIORITY_2_SECTORS,
+    ALL_SECTORS,
+    DISASTER_TYPES,
+)
+
 # Third-party imports
 from dotenv import load_dotenv
 
@@ -33,45 +41,7 @@ DEFAULT_OUTPUT_FILE = "disaster_impact_report.xlsx"
 MIN_DISASTER_NAME_LENGTH = 2
 MAX_DISASTER_NAME_LENGTH = 100
 
-# Define available sectors (moved to constants for better maintainability)
-PRIORITY_1_SECTORS = [
-    "Chemical",
-    "Commercial Facilities",
-    "Communications",
-    "Critical Manufacturing",
-    "Dams",
-    "Emergency Services",
-    "Information Technology",
-    "Nuclear",  # Shortened from "Nuclear Reactors, Materials, and Waste"
-    "Transportation",  # Shortened from "Transportation Systems"
-    "Government Facilities",
-]
 
-PRIORITY_2_SECTORS = [
-    "Energy",
-    "Water",  # Shortened from "Water and Wastewater Systems"
-    "Defense",  # Shortened from "Defense Industrial Base"
-    "Financial",  # Shortened from "Financial Services"
-    "Healthcare",  # Shortened from "Healthcare and Public Health"
-    "Food and Agriculture",
-]
-
-ALL_SECTORS = PRIORITY_1_SECTORS + PRIORITY_2_SECTORS
-
-# Define disaster types
-DISASTER_TYPES = [
-    "Hurricane",
-    "Earthquake",
-    "Flood",
-    "Fire",
-    "Tornado",
-    "Tsunami",
-    "Drought",
-    "Landslide",
-    "Volcanic Eruption",
-    "Winter Storm",
-    "Heat Wave",
-]
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- import sector and disaster lists from `config`
- remove duplicated lists from `main.py` and GUI
- expose lists via `src.__init__` for convenience

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877e9b266d08331a8a86b2a2d838131